### PR TITLE
add mixins

### DIFF
--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -1,0 +1,7 @@
+@mixin page-layout($padding: 200px, $min-height: 100vh) {
+    padding-left: $padding;
+    padding-right: $padding;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}


### PR DESCRIPTION
Add a new mixin for page layout styling

- Created a mixin `page-layout` for setting page spacing, flex layout, and gap between child elements.
- Located in `styles/mixins`.
- Usage: `@include page-layout($padding, $min-height)`.
- Don't forget to `@import` the mixin before using it.

Default values:
- Left/right padding: 200px
- Min height: 100vh
- Flex direction: column
- Gap between children: 20px
