### PR TITLE
feat(HobbyDataBubble): Add component to display number of people continuing a hobby

### DIFF
--- a/app/components/HobbyDataBubble/index.jsx
+++ b/app/components/HobbyDataBubble/index.jsx
@@ -1,0 +1,41 @@
+/*
+  This component, made by Refael, displays the number of people who continue hobbies.
+
+  It has two modes:
+  1. Default mode - Shows the number of people continuing a specific hobby.
+  2. SUM mode - Shows the total number of people continuing all hobbies.
+*/
+"use client";
+import useRand from "@/hooks/useRand";
+import styles from "./style.module.scss";
+import DynamicBackground from "../DynamicBackground";
+
+export default function HobbyDataBubble({
+    hobbyName = "טניס",
+    hobbyContinuers = 136,
+    hobbyContinuersSum = 230,
+    fallenName = "מאי",
+    sumMode = true,
+    onClick,
+}) {
+    const rand = useRand();
+
+    if (!rand) {
+        return <div className={styles.loading}>loading...</div>;
+    }
+
+    return (
+        <DynamicBackground rand={rand}>
+            <div className={styles.hobbyDataBubble} onClick={onClick}>
+                <div className={styles.hobbyContinuers}>
+                    {sumMode ? hobbyContinuersSum : hobbyContinuers}
+                </div>
+                <div className={styles.hobbyText}>
+                    {sumMode
+                        ? `זוכרים את ${fallenName} וממשיכים בדרכה`
+                        : `ממשיכים בתחביב ה${hobbyName} לזכר ${fallenName}`}
+                </div>
+            </div>
+        </DynamicBackground>
+    );
+}

--- a/app/components/HobbyDataBubble/style.module.scss
+++ b/app/components/HobbyDataBubble/style.module.scss
@@ -1,0 +1,21 @@
+@use '@/styles/_vars.scss' as *;
+
+@use 'sass:color';
+
+.hobbyDataBubble {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: start;
+    padding: 10px;
+    width: 300px;
+    aspect-ratio: 3;
+    font-size: 18px;
+    color: $bubbleTextColor;
+
+    .hobbyContinuers {
+        font-size: $text-xl;
+        font-weight: bold;
+        color: $titleColor;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "remember",
       "version": "0.1.0",
       "dependencies": {
+        "@react-oauth/google": "^0.12.1",
         "dotenv": "^16.4.7",
         "next": "15.1.6",
         "react": "^19.0.0",
@@ -827,6 +828,15 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.12.1.tgz",
+      "integrity": "sha512-qagsy22t+7UdkYAiT5ZhfM4StXi9PPNvw0zuwNmabrWyMKddczMtBIOARflbaIj+wHiQjnMAsZmzsUYuXeyoSg==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@swc/counter": {


### PR DESCRIPTION
- Added the `HobbyDataBubble` component, which displays the number of people continuing a hobby.
- The component supports two modes:
  1. **Default mode** – Displays the number of people continuing a specific hobby.
  2. **SUM mode** – Displays the total number of people continuing all hobbies.

## Fixes and Improvements:
- Fixed an issue in conditional rendering (`rand` check) to avoid unnecessary JSX nesting.