### PR TITLE
feat: now clicking a profile card in the all-fallen page will navigate to the right page

### DIFF
--- a/app/all-fallen/[fallen]/page.jsx
+++ b/app/all-fallen/[fallen]/page.jsx
@@ -1,0 +1,83 @@
+import HobbyBubble from "@/app/components/HobbyBubble";
+import HobbyDataBubble from "@/app/components/HobbyDataBubble";
+import ProfileCard from "@/app/components/ProfileCard";
+import Button from "@/app/components/Button";
+import TitleDivider from "@/app/components/TitleDivider";
+import styles from "./page.module.scss";
+
+export default async function FallenPage({ params }) {
+  const fallenId = (await params).fallen;
+
+  // TODO: Generlize base URL depending on the environment
+  const fallenDetails = await fetch(
+    `http://localhost:3000/api/fallen/${fallenId}`
+  )
+    .then((response) => response.json())
+    .then((data) => data);
+
+  const hobbies = ["טניס", "שירה", "ריצה", "אפיה", "סריגה", "שחיה"];
+  const hh = ["טניס", "שירה", "ריצה"];
+  const { firstName, lastName, birthYear, deathYear, imageSrc } = {
+    firstName: "מאי",
+    lastName: "הלל",
+    birthYear: "2000",
+    deathYear: "2023",
+    imageSrc: "/profileImage.webp",
+  };
+  const mainTitle = "תמשיכו לבנות לגו. זה החלום והתחביב הכי גדול שלי";
+  const aboutParagraph =
+    "Lorem, ipsum dolor sit amet consectetur adipisicing elit. Nihil reiciendis, rerum tempore officiis molestias ab consequuntur est, doloremque accusamus reprehenderit quod voluptates enim, deleniti ex atque sint quisquam? Debitis, officiis!";
+  const additionalParagraph =
+    "Lorem ipsum dolor sit amet consectetur adipisicing elit. Facilis, perferendis, sequi dolore quisquam obcaecati molestiae consequuntur minus laboriosam est itaque qui saepe provident, iusto in quod! Consectetur voluptates alias velit?";
+
+  return (
+    <>
+      <div className={styles.fallen}>
+        <div className={`${styles.rightCol} ${styles.col}`}>
+          <ProfileCard fallen={fallenDetails} />
+          <div>
+            <TitleDivider title={"התחביבים שלי"} />
+            <div className={styles.hobbies}>
+              {hobbies.map((hobby) => (
+                <HobbyBubble
+                  key={hobby}
+                  children={hobby}
+                  className={styles.hobby}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className={`${styles.middleCol} ${styles.col}`}>
+          <h1 className={styles.mainTitle}>{mainTitle}</h1>
+          <div>
+            <TitleDivider title={"התחביבים שלי"} />
+            <p className={styles.paragraph}>{aboutParagraph}</p>
+          </div>
+          <div>
+            <TitleDivider title={"קצת עליי"} />
+            <p className={styles.paragraph}>{additionalParagraph}</p>
+          </div>
+        </div>
+        <div className={`${styles.leftCol} ${styles.col}`}>
+          <div>
+            <div className={styles.hobbiesWithData}>
+              {hh.map((hobby, index) => (
+                <HobbyDataBubble
+                  hobbyName={hobby}
+                  sumMode={false}
+                  key={index}
+                />
+              ))}
+            </div>
+            <div>
+              <TitleDivider title={'סה"כ'} />
+              <HobbyDataBubble sumMode={true} />
+            </div>
+          </div>
+          <Button className={styles.button} children={"שיתוף"} />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/all-fallen/[fallen]/page.module.scss
+++ b/app/all-fallen/[fallen]/page.module.scss
@@ -1,0 +1,70 @@
+@use '@/styles/_vars.scss'as *;
+@import '@/styles/_mixins.scss';
+
+
+.fallen {
+    @include page-layout(200px);
+    flex-direction: row;
+
+    .col {
+        margin: 0;
+        padding: 15px 15px;
+        height: 884px;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        gap: 20px;
+        border-width: 0px 1px 1px 1px;
+        background: $elementGradient;
+        border-color: $lightblueBorder;
+        border-style: solid;
+        border-radius: 0px 0px 10px 10px;
+    }
+
+    .rightCol {
+        min-width: 335px;
+
+        .hobbies {
+            display: flex;
+            flex-direction: row;
+            justify-content: space-around;
+            flex-wrap: wrap;
+            padding: 5px 0;
+            gap: 15px 0;
+        }
+    }
+
+    .middleCol {
+        width: 690px;
+
+        .mainTitle {
+            width: 610px;
+            font-family: $font-family;
+            font-size: $text-xxl;
+            color: $titleColor;
+        }
+
+        .paragraph {
+            font-size: $text-base;
+            color: $textColor;
+            font-family: $font-family;
+        }
+    }
+
+    .leftCol {
+        width: 335px;
+
+        .hobbiesWithData {
+            gap: 20px;
+            padding: 20px 0;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: wrap;
+        }
+
+        .button {
+            height: 48px;
+        }
+    }
+
+}

--- a/app/all-fallen/page.jsx
+++ b/app/all-fallen/page.jsx
@@ -8,7 +8,7 @@ import CustomBubble from "../components/CustomBubble";
 import TitleDivider from "../components/TitleDivider";
 
 export default async function AllFallenPage({ searchParams }) {
-  const  q = (await searchParams).q || "";
+  const q = (await searchParams).q || "";
   // TODO: Replace dummy data in real hobbies from API
   const hobbies = ["טניס", "שירה", "ריצה", "אפיה", "סריגה", "שחיה"];
 
@@ -54,13 +54,7 @@ function FallenList({ fallenPromise }) {
     <>
       {fallen.map((fallen) => (
         <div className={styles.cardBackground} key={fallen.id}>
-          <ProfileCard
-            firstName={fallen.firstName}
-            lastName={fallen.lastName}
-            birthYear={fallen.birthYear}
-            deathYear={fallen.deathYear}
-            imageUrl={fallen.imageUrl}
-          />
+          <ProfileCard fallen={fallen} />
         </div>
       ))}
     </>

--- a/app/api/fallen/[id]/route.js
+++ b/app/api/fallen/[id]/route.js
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { getFallenById } from "@/server/service/fallen.service";
+
+export async function GET(request, { params }) {
+  const { id } = await params;
+  const fallen = await getFallenById(id);
+
+  if (!fallen) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(fallen);
+}

--- a/app/components/HobbyTag/index.jsx
+++ b/app/components/HobbyTag/index.jsx
@@ -3,14 +3,19 @@
 import useRand from "@/hooks/useRand";
 import styles from "./style.module.scss";
 import DynamicBackground from "../DynamicBackground";
+import { useRouter, useSearchParams } from "next/navigation";
 
-export default function HobbyTag({
-  hobby,
-  className = "",
-  onClick,
-  ...props
-}) {
+export default function HobbyTag({ hobby, className = "", onClick, ...props }) {
   const rand = useRand();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  onClick = () => {
+    const params = new URLSearchParams(searchParams);
+    params.set("q", hobby);
+
+    router.push(`?${params.toString()}`, { scroll: false });
+  };
 
   return (
     <>

--- a/app/components/ImageWithTitle/Index.jsx
+++ b/app/components/ImageWithTitle/Index.jsx
@@ -1,12 +1,13 @@
 import React from "react";
 import styles from "./style.module.scss";
 
-const ImageWithTitle = ({ imageUrl, title, subtitle,onClick }) => {
+const ImageWithTitle = ({ imageUrl, title, subtitle,onClick , style}) => {
   return (
     <div
       className={styles.imageWithTitle}
       style={{
         backgroundImage: `url(${imageUrl})`,
+        ...style,
       }}
       onClick={onClick} 
       role={onClick ? "button" : undefined} 

--- a/app/components/ImageWithTitle/index.jsx
+++ b/app/components/ImageWithTitle/index.jsx
@@ -1,12 +1,13 @@
 import React from "react";
 import styles from "./style.module.scss";
 
-const ImageWithTitle = ({ imageUrl, title, subtitle,onClick }) => {
+const ImageWithTitle = ({ imageUrl, title, subtitle,onClick , style}) => {
   return (
     <div
       className={styles.imageWithTitle}
       style={{
         backgroundImage: `url(${imageUrl})`,
+        ...style,
       }}
       onClick={onClick} 
       role={onClick ? "button" : undefined} 

--- a/app/components/ProfileCard/index.jsx
+++ b/app/components/ProfileCard/index.jsx
@@ -1,31 +1,27 @@
-import styles from "./style.module.scss";
+import Link from "next/link";
 import Image from "next/image";
+import styles from "./style.module.scss";
 
-export default function ProfileCard({
-    firstName = "מאי",
-    lastName = "הלל",
-    birthYear = "2000",
-    deathYear = "2023",
-    imageSrc = "/profileImage.webp",
-}) {
-    return (
-        <div className={styles.card}>
-            <div className={styles.profileImage}>
-                <Image
-                    className={styles.profileImage}
-                    src={imageSrc}
-                    alt={`${firstName} ${lastName}`}
-                    width={150}
-                    height={200}
-                />
-            </div>
-            <div>
-
-            <h3 className={styles.name}>{`${firstName} ${lastName}`}</h3>
-            <p className={styles.years}>
-                {birthYear} - {deathYear}
-            </p>
-            </div>
-        </div>
-    );
+export default function ProfileCard({ fallen }) {
+  return (
+    <Link className={styles.card} href={`/all-fallen/${String(fallen.id)}`}>
+      <div className={styles.profileImage}>
+        <Image
+          className={styles.profileImage}
+          src={fallen.imageUrl}
+          alt={`${fallen.firstName} ${fallen.lastName}`}
+          width={150}
+          height={200}
+        />
+      </div>
+      <div>
+        <h3
+          className={styles.name}
+        >{`${fallen.firstName} ${fallen.lastName}`}</h3>
+        <p className={styles.years}>
+          {fallen.birthYear} - {fallen.deathYear}
+        </p>
+      </div>
+    </Link>
+  );
 }

--- a/server/service/fallen.service.js
+++ b/server/service/fallen.service.js
@@ -86,3 +86,7 @@ export async function getFilteredFallen(query) {
       fallen.hobbies.includes(query)
   );
 }
+
+export async function getFallenById(id) {
+  return fallen.find((fallen) => fallen.id == id);
+}


### PR DESCRIPTION
## PR Description
- Converted the fallen page into a dynamic route segment to support navigation to individual fallen pages.
- Moved the fallen page into the all-fallen directory to align with Next.js file-based routing conventions.
- Added an API endpoint to fetch fallen data by ID.
- Made Profile Cards in the all-fallen page clickable, enabling navigation to the corresponding fallen page.
- Made Hobby Tags clickable, allowing users to filter the fallen list accordingly.