### PR TITLE
fix: showing only approved fallen profiles

### DIFF
--- a/app/all-fallen/FallenList.jsx
+++ b/app/all-fallen/FallenList.jsx
@@ -7,15 +7,19 @@ function FallenList({ fallen }) {
   return (
     <>
       {fallen.length > 0 ? (
-        fallen.map((fallen) => (
-          <Link
-            key={fallen._id}
-            className={styles.cardBackground}
-            href={`/all-fallen/${String(fallen._id)}`}
-          >
-            <ProfileCard fallen={fallen} />
-          </Link>
-        ))
+        fallen.map((fallen) =>
+          fallen.status === "approved" ? (
+            <Link
+              key={fallen._id}
+              className={styles.cardBackground}
+              href={`/all-fallen/${String(fallen._id)}`}
+            >
+              <ProfileCard fallen={fallen} />
+            </Link>
+          ) : (
+            <></>
+          )
+        )
       ) : (
         <StatusMessage
           message="לא נמצאו נופלים התואמים את החיפוש"

--- a/app/all-fallen/page.jsx
+++ b/app/all-fallen/page.jsx
@@ -1,12 +1,12 @@
 import { Suspense } from "react";
-import SearchForm from "./SearchForm";
-import FallenList from "./FallenList";
 import styles from "./page.module.scss";
 import HobbyTag from "../components/HobbyTag";
 import { connectToDB } from "@/server/connect";
 import CustomBubble from "../components/CustomBubble";
 import TitleDivider from "../components/TitleDivider";
 import { metadata as layoutMetadata } from "../layout";
+import SearchForm from "../components/SearchForm/SearchForm";
+import FallenList from "../components/FallenList/FallenList";
 import {
   getAllFallen,
   getFilteredFallen,
@@ -32,7 +32,7 @@ export default async function AllFallenPage({ searchParams }) {
   const q = (await searchParams).q || "";
   const fallen = q ? await getFilteredFallen(q) : await getAllFallen();
 
-  // TODO: Replace dummy data in real hobbies from API
+  // TODO: Replace dummy data in real popular hobbies from API
   const hobbies = ["טניס", "שירה", "ריצה", "אפיה", "סריגה", "שחיה"];
 
   return (

--- a/app/all-fallen/page.module.scss
+++ b/app/all-fallen/page.module.scss
@@ -15,12 +15,6 @@
         font-weight: bold;
         font-size: $text-lg;
     }
-
-    .searchContainer {
-        display: flex;
-        gap: 10px;
-        align-items: center;
-    }
 }
 
 .itemsContainer {
@@ -29,23 +23,9 @@
     gap: 20px;
     justify-content: center;
     width: 100%;
-
-    .cardBackground {
-        background-color: $elementGradient;
-        border-bottom: 1px solid $lightblueBorder;
-        border-left: 1px solid $lightblueBorder;
-        border-right: 1px solid $lightblueBorder;
-        border-radius: 0px 0px 15px 15px;
-        padding: 10px;
-        width: 250px;
-
-        &:hover {
-            cursor: pointer;
-        }
-    }
 }
 
-@media (max-width: 992px) {
+@media (max-width: $breakpoint-lg) {
     .header {
         text-align: center;
     }
@@ -53,16 +33,6 @@
     .customBubble {
         flex-direction: column !important;
 
-    }
-
-    .searchContainer {
-        width: 100%;
-        flex-direction: column;
-    }
-
-    .searchInput,
-    .searchButton {
-        width: 100%;
     }
 
     .itemsContainer {

--- a/app/components/DynamicBackground/index.jsx
+++ b/app/components/DynamicBackground/index.jsx
@@ -1,4 +1,5 @@
 import styles from "./style.module.scss";
+import { colorGenerator, toGrayscale } from "@/lib/colors";
 
 const pastelColors = [
   "#FFF8F8", // Very Light Pink
@@ -12,40 +13,28 @@ const pastelColors = [
   "#FFF9E6", // Creamy Light Yellow
 ];
 
-
-const colorGenrator = (color, percent, type = "light") => {
-  const factor = type === "light" ? [1, 1] : [-1, 0];
-  const num = parseInt(color.replace("#", ""), 16);
-  const amt = Math.round(2.55 * percent);
-  const R = (num >> 16) + factor[0] * amt;
-  const G = ((num >> 8) & 0x00ff) + factor[0] * amt;
-  const B = (num & 0x0000ff) + factor[0] * amt;
-
-  return (
-    "#" +
-    (
-      0x1000000 +
-      (R < 255 ? (R < factor[1] ? 0 : R) : 255) * 0x10000 +
-      (G < 255 ? (G < factor[1] ? 0 : G) : 255) * 0x100 +
-      (B < 255 ? (B < factor[1] ? 0 : B) : 255)
-    )
-      .toString(16)
-      .slice(1)
-  );
-};
-
-export default function DynamicBackground({ children, rand, className = "" }) {
+export default function DynamicBackground({
+  children,
+  rand,
+  active = true,
+  className = "",
+}) {
   const randomColor = pastelColors[Math.floor(rand * pastelColors.length)];
-  const lighterColor = colorGenrator(randomColor, 50, "light");
-  const darkerBorderColor = colorGenrator(randomColor, 10, "dark");
+  const baseColor = active ? randomColor : toGrayscale(randomColor);
+  const lighterColor = active
+    ? colorGenerator(randomColor, 50, "light")
+    : toGrayscale(colorGenerator(randomColor, 50, "light"));
+  const darkerBorderColor = active
+    ? colorGenerator(randomColor, 10, "dark")
+    : toGrayscale(colorGenerator(randomColor, 10, "dark"));
 
   return (
     <div
       className={`${styles.dynamicBackground} ${className}`}
       style={{
-        "--baseColor": randomColor,
+        "--baseColor": baseColor,
         "--lighterColor": lighterColor,
-        "--borderColor": randomColor,
+        "--borderColor": baseColor,
         "--darkerBorderColor": darkerBorderColor,
       }}
     >

--- a/app/components/FallenList/FallenList.jsx
+++ b/app/components/FallenList/FallenList.jsx
@@ -4,22 +4,20 @@ import ProfileCard from "../ProfileCard";
 import StatusMessage from "@/app/components/StatusMessage";
 
 function FallenList({ fallen }) {
+  const approvedFallen = fallen.filter((f) => f.status === "approved");
+
   return (
     <>
-      {fallen.length > 0 ? (
-        fallen.map((fallen) =>
-          fallen.status === "approved" ? (
-            <Link
-              key={fallen._id}
-              className={styles.cardBackground}
-              href={`/all-fallen/${String(fallen._id)}`}
-            >
-              <ProfileCard fallen={fallen} />
-            </Link>
-          ) : (
-            <></>
-          )
-        )
+      {approvedFallen.length > 0 ? (
+        approvedFallen.map((fallen) => (
+          <Link
+            key={fallen._id}
+            className={styles.cardBackground}
+            href={`/all-fallen/${String(fallen._id)}`}
+          >
+            <ProfileCard fallen={fallen} />
+          </Link>
+        ))
       ) : (
         <StatusMessage
           message="לא נמצאו נופלים התואמים את החיפוש"

--- a/app/components/FallenList/FallenList.jsx
+++ b/app/components/FallenList/FallenList.jsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
-import styles from "./page.module.scss";
-import ProfileCard from "../components/ProfileCard";
+import styles from "./style.module.scss";
+import ProfileCard from "../ProfileCard";
 import StatusMessage from "@/app/components/StatusMessage";
 
 function FallenList({ fallen }) {

--- a/app/components/FallenList/style.module.scss
+++ b/app/components/FallenList/style.module.scss
@@ -1,0 +1,15 @@
+@use '@/styles/_vars.scss' as *;
+
+.cardBackground {
+    background-color: $elementGradient;
+    border-bottom: 1px solid $lightblueBorder;
+    border-left: 1px solid $lightblueBorder;
+    border-right: 1px solid $lightblueBorder;
+    border-radius: 0px 0px 15px 15px;
+    padding: 10px;
+    width: 250px;
+
+    &:hover {
+        cursor: pointer;
+    }
+}

--- a/app/components/HobbyDataBubble/index.jsx
+++ b/app/components/HobbyDataBubble/index.jsx
@@ -33,7 +33,6 @@ export default function HobbyDataBubble({
         <div className={styles.hobbyContinuers}>
           {sumMode ? hobbyContinuersSum : hobbyContinuers}
         </div>
-        {/* TODO: Add support for both feminine and masculine forms */}
         <div className={styles.hobbyText}>
           {sumMode
             ? ` ממשיכים בדרך של ${fallenName}`

--- a/app/components/HobbyTag/index.jsx
+++ b/app/components/HobbyTag/index.jsx
@@ -14,6 +14,16 @@ export default function HobbyTag({ hobby, className = "", onClick, ...props }) {
     return new URLSearchParams(params);
   };
 
+  const getChosenHobby = () => {
+    const params = getParams(searchParams);
+
+    return params.get("q");
+  };
+
+  const isChosenHobby = () => {
+    return getChosenHobby() === hobby;
+  };
+
   onClick = () => {
     const params = getParams(searchParams);
     params.set("q", hobby);
@@ -21,23 +31,20 @@ export default function HobbyTag({ hobby, className = "", onClick, ...props }) {
     router.push(`?${params.toString()}`, { scroll: false });
   };
 
-  const isChosenHobby = () => {
-    const params = getParams(searchParams);
-
-    return params.get("q") === hobby;
-  };
-
   return (
     <>
       {rand ? (
-        <DynamicBackground rand={rand} className={styles.dynamicBackground}>
+        <DynamicBackground
+          rand={rand}
+          active={getChosenHobby() ? isChosenHobby() : true}
+          className={styles.dynamicBackground}
+        >
           <div
             className={`${styles.hobbyTag} ${className}`}
             onClick={onClick}
             {...props}
           >
             {hobby}
-            {isChosenHobby() && <div className={styles.checkContainer}></div>}
           </div>
         </DynamicBackground>
       ) : (

--- a/app/components/HobbyTag/style.module.scss
+++ b/app/components/HobbyTag/style.module.scss
@@ -19,15 +19,6 @@
     &:hover {
         cursor: pointer;
     }
-
-    .checkContainer {
-        position: absolute;
-        right: 5;
-        top: 5;
-        background-color: $primary;
-        border-radius: 100%;
-        padding: 4px;
-    }
 }
 
 @media (max-width: $breakpoint-md) {

--- a/app/components/SearchForm/SearchForm.jsx
+++ b/app/components/SearchForm/SearchForm.jsx
@@ -1,9 +1,9 @@
 "use client";
 
-import styles from "./page.module.scss";
-import Button from "../components/Button";
+import Button from "../Button";
+import styles from "./style.module.scss";
+import SearchInput from "../SearchInput";
 import { useRouter, useSearchParams } from "next/navigation";
-import SearchInput from "../components/SearchInput";
 
 const SearchForm = ({ query }) => {
   const router = useRouter();

--- a/app/components/SearchForm/style.module.scss
+++ b/app/components/SearchForm/style.module.scss
@@ -1,0 +1,19 @@
+@use '@/styles/_vars.scss' as *;
+
+.searchContainer {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+}
+
+@media (max-width: $breakpoint-lg) {
+    .searchContainer {
+        width: 100%;
+        flex-direction: column;
+    }
+
+    .searchInput,
+    .searchButton {
+        width: 100%;
+    }
+}

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -1,0 +1,29 @@
+export const colorGenerator = (color, percent, type = "light") => {
+  const factor = type === "light" ? [1, 1] : [-1, 0];
+  const num = parseInt(color.replace("#", ""), 16);
+  const amt = Math.round(2.55 * percent);
+  const R = (num >> 16) + factor[0] * amt;
+  const G = ((num >> 8) & 0x00ff) + factor[0] * amt;
+  const B = (num & 0x0000ff) + factor[0] * amt;
+
+  return (
+    "#" +
+    (
+      0x1000000 +
+      (R < 255 ? (R < factor[1] ? 0 : R) : 255) * 0x10000 +
+      (G < 255 ? (G < factor[1] ? 0 : G) : 255) * 0x100 +
+      (B < 255 ? (B < factor[1] ? 0 : B) : 255)
+    )
+      .toString(16)
+      .slice(1)
+  );
+};
+
+export const toGrayscale = (color) => {
+  const num = parseInt(color.replace("#", ""), 16);
+  const R = (num >> 16) & 0xff;
+  const G = (num >> 8) & 0xff;
+  const B = num & 0xff;
+  const gray = Math.round(0.3 * R + 0.59 * G + 0.11 * B); // Standard grayscale formula
+  return `#${gray.toString(16).padStart(2, "0").repeat(3)}`;
+};


### PR DESCRIPTION
## PR Description

- Now displaying only approved fallen profiles on the `all-fallen-page`.
- Refactored the page structure by moving page-related components from the page directory to the components directory.
- Removed the dot indicator in the hobbies filter.
- Updated hobby tags to appear in full color when no filter is applied and switch to grayscale when a hobby filter is active.