### PR TITLE
Add mobile dropdown filter, fix search logic, improve responsive layo…

### DIFF
--- a/app/add-fallen/page.jsx
+++ b/app/add-fallen/page.jsx
@@ -163,7 +163,6 @@ const handleSubmit = async (e) => {
         continueCount: 0
       }));
 
-    // שימוש ב-Server Action
     try {
       const result = await addFallen({
         firstName: formData.firstName,
@@ -370,7 +369,7 @@ const handleSubmit = async (e) => {
                 required
               />
               <input
-                type="number"
+                type="tel"
                 name="phone"
                 value={formData.phone}
                 onChange={handleChange}

--- a/app/all-fallen/[fallen]/components/ShareButton/style.module.scss
+++ b/app/all-fallen/[fallen]/components/ShareButton/style.module.scss
@@ -1,5 +1,5 @@
 
-.button {
-    aspect-ratio: 5;
-    width: 100%
-}
+// .button {
+//     aspect-ratio: 5;
+//     width: 100%
+// }

--- a/app/all-fallen/[fallen]/page.module.scss
+++ b/app/all-fallen/[fallen]/page.module.scss
@@ -7,7 +7,6 @@
     gap: $spacing-md;
     height: calc(100vh - $footerHeight - $headerHeight);
 
-
     .title {
         color: $titleColor;
     }
@@ -23,7 +22,6 @@
         border-style: solid;
         border-radius: 0px 0px 10px 10px;
     }
-
 
     .rightCol {
         width: 25%;
@@ -50,23 +48,16 @@
                 color: $textColor;
                 font-family: $font-family;
             }
-
         }
     }
 
     .leftCol {
         width: 25%;
-        // justify-content: space-between;
         padding-top: 0;
     }
-
 }
 
 @media (max-width: $breakpoint-lg) {
-    .sctionsDivider {
-        // display: none !important;
-    }
-
     .totalDivider {
         flex-direction: row !important;
     }
@@ -74,25 +65,70 @@
     .fallen {
         flex-direction: column;
         height: auto;
-
+        align-items: center;
+        
         .hobbiesDivider {
             display: none !important;
         }
-
+        
         .col {
             height: auto;
             overflow-y: visible;
+            max-width: 800px;
+            width: 50%;
         }
+    }
+}
 
-        .rightCol {
+@media (max-width: $breakpoint-md2) {
+    .fallen {
+        .col {
+            width: 60%;
+            max-width: 720px;
+        }
+    }
+}
+
+@media (max-width: $breakpoint-md) {
+    .fallen {
+        .col {
+            width: 70%;
+            max-width: 650px;
+        }
+    }
+}
+
+@media (max-width: $breakpoint-sm) {
+    .fallen {
+        .col {
+            width: 80%;
+            max-width: 580px;
+        }
+    }
+}
+
+@media (max-width: $breakpoint-xs) {
+    .totalDivider {
+        flex-direction: row !important;
+    }
+
+    .fallen {
+        flex-direction: column;
+        height: auto;
+        
+        .hobbiesDivider {
+            display: none !important;
+        }
+        
+        .col {
+            height: auto;
+            overflow-y: visible;
             width: 100%;
+            padding: 15px 10px;
+            max-width: none;
         }
-
-        .middleCol {
-            width: 100%;
-        }
-
-        .leftCol {
+        
+        .rightCol, .middleCol, .leftCol {
             width: 100%;
         }
     }

--- a/app/components/Button/style.module.scss
+++ b/app/components/Button/style.module.scss
@@ -10,7 +10,6 @@
     border: none;
     cursor: pointer;
     transition: all 0.3s;
-
     &:hover {
         background-color: $titleColor;
     }

--- a/app/components/HobbyBubble/index.jsx
+++ b/app/components/HobbyBubble/index.jsx
@@ -28,10 +28,18 @@ export default function HobbyBubble({
       // אם יש פונקציית onClick מבחוץ, משתמשים בה
       onClick();
     } else {
-      // אחרת, מנווטים לעמוד הנופלים עם פרמטר התחביב
-      const params = new URLSearchParams(searchParams);
-      params.delete("page");
-      params.set("hobby", children);
+      // יצירת אובייקט פרמטרים חדש
+      const params = new URLSearchParams();
+      
+      // הנקודה החשובה: אנחנו מגדירים את התחביב כפרמטר q
+      // זה יחליף את השם שהיה בתיבת החיפוש בתחביב
+      params.set("q", children);
+      
+      // שמירה על פרמטרים אחרים שאינם קשורים לחיפוש
+      const currentParams = new URLSearchParams(searchParams);
+      if (currentParams.has("sort")) {
+        params.set("sort", currentParams.get("sort"));
+      }
 
       router.push(`/fallen?${params.toString()}`, { scroll: false });
     }

--- a/app/components/HobbyDataBubble/style.module.scss
+++ b/app/components/HobbyDataBubble/style.module.scss
@@ -17,6 +17,8 @@
     aspect-ratio: 3;
     font-size: $text-md;
     color: $bubbleTextColor;
+    max-height: 80px;
+
 
     .hobbyContinuers {
         font-size: $text-xl;

--- a/app/components/HobbyTag/index.jsx
+++ b/app/components/HobbyTag/index.jsx
@@ -25,10 +25,22 @@ export default function HobbyTag({
   const handleClick = () => {
     if (!isClickable) return;
 
-    const params = getParams();
-    params.delete("page");
-    params.set("q", hobby);
+    const searchInput = document.querySelector('input[name="q"]');
+    if (searchInput) {
+      searchInput.value = hobby;
+      
+      const event = new Event('change', { bubbles: true });
+      searchInput.dispatchEvent(event);
+    }
 
+    const params = new URLSearchParams();
+    params.set("q", hobby);
+    
+    const currentParams = getParams();
+    if (currentParams.has("sort")) {
+      params.set("sort", currentParams.get("sort"));
+    }
+    
     router.push(`?${params.toString()}`, { scroll: false });
   };
 

--- a/app/components/MobileFilterDropdown/Index.jsx
+++ b/app/components/MobileFilterDropdown/Index.jsx
@@ -1,0 +1,48 @@
+"use client";
+
+import React, { useState } from "react";
+import HobbyTag from "../HobbyTag";
+import styles from "./style.module.scss";
+
+export default function MobileFilterDropdown({ 
+  hobbies = [],
+  isClickable = false
+}) {
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  const toggleDropdown = () => {
+    setIsDropdownOpen(!isDropdownOpen);
+  };
+
+  return (
+    <div className={styles.mobileMenuContainer}>
+      <button 
+        className={`${styles.dropdownButton} ${isDropdownOpen ? styles.active : ""}`}
+        onClick={toggleDropdown}
+        aria-expanded={isDropdownOpen}
+        aria-controls="mobile-filter-dropdown"
+      >
+        סינון לפי תחביבים נפוצים
+        <span className={styles.dropdownIcon}>
+          {isDropdownOpen ? '▲' : '▼'}
+        </span>
+      </button>
+      
+      {isDropdownOpen && (
+        <div 
+          id="mobile-filter-dropdown"
+          className={styles.dropdownContent}
+        >
+          {hobbies && hobbies.length > 0 && hobbies.map((hobby, index) => (
+            <HobbyTag
+              hobby={hobby._id}
+              key={index}
+              title={`${hobby.fallenCount} נופלים`}
+              isClickable={isClickable}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/MobileFilterDropdown/style.module.scss
+++ b/app/components/MobileFilterDropdown/style.module.scss
@@ -1,0 +1,65 @@
+@use '@/styles/_vars.scss' as *;
+
+.mobileMenuContainer {
+  width: 100%;
+  position: relative;
+  margin: 10px 0;
+  display: none;
+}
+
+.dropdownButton {
+  width: 100%;
+  padding: 10px;
+  background-color: #f5f5f5;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  font-size: 1rem;
+  text-align: center;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  
+  &:hover {
+    background-color: #eaeaea;
+  }
+  
+  &.active {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    background-color: #eaeaea;
+  }
+}
+
+.dropdownIcon {
+  font-size: 0.8rem;
+  margin-right: 4px;
+}
+
+.dropdownContent {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  border: 1px solid #e0e0e0;
+  border-top: none;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  padding: 10px;
+  background-color: #ffffff;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+@media (max-width: $breakpoint-xs) {
+  .mobileMenuContainer {
+    display: block;
+  }
+}
+
+@media (min-width: $breakpoint-xs) {
+  .mobileMenuContainer {
+    display: none;
+  }
+}

--- a/app/components/PopularHobbies/index.jsx
+++ b/app/components/PopularHobbies/index.jsx
@@ -1,9 +1,10 @@
 import React from "react";
-import HobbyTag from "../HobbyTag";
 import styles from "./style.module.scss";
 import HobbyBubble from "../HobbyBubble";
 import { connectToDB } from "@/server/connect";
 import { getPopularHobbies } from "@/server/service/fallen.service";
+import HobbyTag from "../HobbyTag";
+import MobileFilterDropdown from "../MobileFilterDropdown/Index";
 
 export default async function PopularHobbies({ 
   displayMode = "home",
@@ -17,11 +18,15 @@ export default async function PopularHobbies({
   }`;
 
   const tagsClasses = `${styles.hobbyTagsContainer} ${
-    displayMode === "fallen" ? styles.alwaysVisible : ""
+    displayMode === "fallen" ? styles.desktopOnly : ""
   }`;
+
+  // visible only on mobile fallen page
+  const isFallenPage = displayMode === "fallen";
 
   return (
     <>
+      {/* bubbles on regular page */}
       <div className={bubblesClasses}>
         {hobbies.map((hobby, index) => (
           <HobbyBubble
@@ -36,6 +41,12 @@ export default async function PopularHobbies({
         ))}
       </div>
 
+      {/* {mobile menu only visible on fallen page} */}
+      {isFallenPage && (
+        <MobileFilterDropdown hobbies={hobbies} isClickable={isClickable} />
+      )}
+
+      {/* tags - if it is a fallen page, or if it's not a fallen page */}
       <div className={tagsClasses}>
         {hobbies.map((hobby, index) => (
           <HobbyTag

--- a/app/components/PopularHobbies/style.module.scss
+++ b/app/components/PopularHobbies/style.module.scss
@@ -16,14 +16,19 @@
   width: 100%;
 }
 
+.desktopOnly {
+  @media (max-width: $breakpoint-xs) {
+    display: none !important;
+  }
+  
+  @media (min-width: $breakpoint-xs) {
+    display: flex !important;
+  }
+}
 
 @media (max-width: $breakpoint-xs) {
   .hobbyBubblesContainer {
     display: none;
-  }
-  
-  .hobbyTagsContainer {
-    display: flex;
   }
 }
 

--- a/app/components/TitleDivider/style.module.scss
+++ b/app/components/TitleDivider/style.module.scss
@@ -33,6 +33,12 @@
 @media (max-width: $breakpoint-md) {
   .container {
     flex-direction: column;
+    gap: 10px;
+
+    .title {
+      text-align: center;
+    }
+
     
     &.lineOnly {
       flex-direction: row;

--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -27,7 +27,7 @@
 @mixin custom-scrollbar { 
   overflow-y: auto;
   padding: 10px 5px;
-  margin-left: -10px;
+  // margin-left: -10px;
 
   &::-webkit-scrollbar {
     width: 4px;


### PR DESCRIPTION
## 1. Mobile Dropdown Menu for Fallen Page

Added a dropdown menu for mobile screens that displays hobbies and topics in a space-efficient manner. The dropdown is only shown when `displayMode === "fallen"` and on mobile screens.

- Created dedicated `MobileMenu` component
- Added responsive styles that show dropdown only on mobile
- Hidden regular tags on mobile while displaying them on desktop
- Implemented open/close behavior for dropdown

## 2. OR Search Condition Instead of AND

Modified search behavior so when a user clicks on a hobby, the system removes the previous name search and replaces it with the hobby in the search field.

- Updated `HobbyTag` to change search parameter `q` to hobby value on click
- Directly updated search field value via DOM
- Preserved other parameters (such as sorting) when creating new URL

## 3. Improved Responsive Display for Fallen Page

Made gradual adjustments to display across different screen sizes to prevent abrupt changes.
- Centered content in row layout
- Adjusted padding based on screen size